### PR TITLE
Made the brewing stand fire tweak configurable

### DIFF
--- a/src/main/java/zabi/minecraft/extraalchemy/client/screen/ConfigScreenProvider.java
+++ b/src/main/java/zabi/minecraft/extraalchemy/client/screen/ConfigScreenProvider.java
@@ -113,6 +113,31 @@ public class ConfigScreenProvider implements ModMenuApi {
 		);
 
 		general.addEntry(configBuilder.entryBuilder()
+				.startIntField(Text.translatable("extraalchemy.config.general.brewing_stand_heat_increment_delay") , ModConfig.INSTANCE.brewingStandHeatIncrementDelay)
+					.setDefaultValue(2)
+					.setTooltip(
+							Text.translatable("extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1"), 
+							Text.translatable("extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2"),
+							SERVER_SIDE
+					)
+					.setSaveConsumer(val -> {ModConfig.INSTANCE.brewingStandHeatIncrementDelay = val;})
+					.build()
+		);
+
+
+		general.addEntry(configBuilder.entryBuilder()
+				.startIntField(Text.translatable("extraalchemy.config.general.brewing_stand_fire_max_capacity") , ModConfig.INSTANCE.brewingStandFireMaxCapacity)
+					.setDefaultValue(20)
+					.setTooltip(
+							Text.translatable("extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1"), 
+							Text.translatable("extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2"),
+							SERVER_SIDE
+					)
+					.setSaveConsumer(val -> {ModConfig.INSTANCE.brewingStandFireMaxCapacity = val;})
+					.build()
+		);
+
+		general.addEntry(configBuilder.entryBuilder()
 				.startBooleanToggle(Text.translatable("extraalchemy.config.general.anchor_depletes") , ModConfig.INSTANCE.useAnchorChargesWithReturnPotion)
 					.setDefaultValue(true)
 					.setTooltip(

--- a/src/main/java/zabi/minecraft/extraalchemy/config/ConfigInstance.java
+++ b/src/main/java/zabi/minecraft/extraalchemy/config/ConfigInstance.java
@@ -7,6 +7,8 @@ public class ConfigInstance {
 	public boolean enableVials;
 	public boolean enableRings;
 	public boolean enableBrewingStandFire;
+	public int brewingStandHeatIncrementDelay;
+	public int brewingStandFireMaxCapacity;
 	public boolean useAnchorChargesWithReturnPotion;
 	public boolean allowRingsInInventoryWithThirdPartyMods;
 	public boolean showIconsInTooltips;
@@ -19,6 +21,8 @@ public class ConfigInstance {
 		enableVials = true;
 		enableRings = true;
 		enableBrewingStandFire = true;
+		brewingStandHeatIncrementDelay = 40;
+		brewingStandFireMaxCapacity = 20;
 		useAnchorChargesWithReturnPotion = true;
 		allowRingsInInventoryWithThirdPartyMods = false;
 		showIconsInTooltips = true;

--- a/src/main/java/zabi/minecraft/extraalchemy/config/ConfigInstance.java
+++ b/src/main/java/zabi/minecraft/extraalchemy/config/ConfigInstance.java
@@ -21,7 +21,7 @@ public class ConfigInstance {
 		enableVials = true;
 		enableRings = true;
 		enableBrewingStandFire = true;
-		brewingStandHeatIncrementDelay = 40;
+		brewingStandHeatIncrementDelay = 2;
 		brewingStandFireMaxCapacity = 20;
 		useAnchorChargesWithReturnPotion = true;
 		allowRingsInInventoryWithThirdPartyMods = false;

--- a/src/main/java/zabi/minecraft/extraalchemy/mixin/common/BrewingStandMixin.java
+++ b/src/main/java/zabi/minecraft/extraalchemy/mixin/common/BrewingStandMixin.java
@@ -40,7 +40,7 @@ public abstract class BrewingStandMixin extends LockableContainerBlockEntity imp
 
 	public void mixinLogicProxy() {
 		if (!world.isClient && ModConfig.INSTANCE.enableBrewingStandFire) {
-			if (fuel < BREWING_STAND_MAX_FUEL_CAPACITY && isHeated(world, pos) && world.getTime() % BREWING_STAND_HEAT_INCREMENT_DELAY_TICKS == 0) {
+			if (fuel < BREWING_STAND_MAX_FUEL_CAPACITY && world.getTime() % BREWING_STAND_HEAT_INCREMENT_DELAY_TICKS == 0 && isHeated(world, pos)) {
 				fuel++;
 				this.markDirty();
 			}

--- a/src/main/java/zabi/minecraft/extraalchemy/mixin/common/BrewingStandMixin.java
+++ b/src/main/java/zabi/minecraft/extraalchemy/mixin/common/BrewingStandMixin.java
@@ -26,6 +26,8 @@ public abstract class BrewingStandMixin extends LockableContainerBlockEntity imp
 	
 	private static final TagKey<Block> HEAT_SOURCE_TAG = TagKey.of(Registry.BLOCK_KEY, LibMod.id("heat_source"));
 	private static final TagKey<Block> HEAT_CONDUCTOR_TAG = TagKey.of(Registry.BLOCK_KEY, LibMod.id("heat_conductor"));
+	private static final int BREWING_STAND_MAX_FUEL_CAPACITY = Math.min(20, ModConfig.INSTANCE.brewingStandFireMaxCapacity);
+	private static final int BREWING_STAND_HEAT_INCREMENT_DELAY_TICKS = 20 * ModConfig.INSTANCE.brewingStandHeatIncrementDelay;
 	
 	protected BrewingStandMixin(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
 		super(blockEntityType, blockPos, blockState);
@@ -38,7 +40,7 @@ public abstract class BrewingStandMixin extends LockableContainerBlockEntity imp
 
 	public void mixinLogicProxy() {
 		if (!world.isClient && ModConfig.INSTANCE.enableBrewingStandFire) {
-			if (fuel < ModConfig.INSTANCE.brewingStandFireMaxCapacity && world.getTime() % (20 * ModConfig.INSTANCE.brewingStandHeatIncrementDelay) == 0 && isHeated(world, pos)) {
+			if (fuel < BREWING_STAND_MAX_FUEL_CAPACITY && isHeated(world, pos) && world.getTime() % BREWING_STAND_HEAT_INCREMENT_DELAY_TICKS == 0) {
 				fuel++;
 				this.markDirty();
 			}

--- a/src/main/java/zabi/minecraft/extraalchemy/mixin/common/BrewingStandMixin.java
+++ b/src/main/java/zabi/minecraft/extraalchemy/mixin/common/BrewingStandMixin.java
@@ -38,7 +38,7 @@ public abstract class BrewingStandMixin extends LockableContainerBlockEntity imp
 
 	public void mixinLogicProxy() {
 		if (!world.isClient && ModConfig.INSTANCE.enableBrewingStandFire) {
-			if (fuel < 20 && world.getTime() % 40 == 0 && isHeated(world, pos)) {
+			if (fuel < ModConfig.INSTANCE.brewingStandFireMaxCapacity && world.getTime() % (20 * ModConfig.INSTANCE.brewingStandHeatIncrementDelay) == 0 && isHeated(world, pos)) {
 				fuel++;
 				this.markDirty();
 			}

--- a/src/main/resources/assets/extraalchemy/lang/en_us.json
+++ b/src/main/resources/assets/extraalchemy/lang/en_us.json
@@ -151,9 +151,17 @@
 	"extraalchemy.config.general.enable_rings.tooltip2": "with a potion to create Potion Rings.",
 	
 	"extraalchemy.config.general.enable_brewing_stand_fire": "Enable Brewing stand fire tweak",
-	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip1": "Enabling this makes the Brewing Stand get fuel every", 
-	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip2": "2 seconds when a heat source is placed underneath.",
+	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip1": "Enabling this makes the Brewing Stand get fuel", 
+	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip2": "when a heat source is placed underneath.",
 	
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay": "Brewing stand heat accumulation speed",
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1": "Specify the number of seconds that need to pass", 
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2": "for the brewing speed to get heat from a heat source.",
+
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity": "Brewing stand heat limit",
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1": "Specify the maximum capacity (1-20) that the Brewing stand", 
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2": "can accumulate from a heat source underneath.",
+
 	"extraalchemy.config.general.anchor_depletes": "Deplete Anchor on return",
 	"extraalchemy.config.general.anchor_depletes.tooltip1": "Enabling this makes the Respawn Anchor lose a charge", 
 	"extraalchemy.config.general.anchor_depletes.tooltip2": "when players teleport to it with the Return effect.",

--- a/src/main/resources/assets/extraalchemy/lang/it_it.json
+++ b/src/main/resources/assets/extraalchemy/lang/it_it.json
@@ -154,13 +154,13 @@
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip1": "Abilitare questa opzione fa si che gli alambicchi vengano", 
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip2": "scaldati ogni 2 secondi se c'è una fonte di calore sotto.",
 	
-	"extraalchemy.config.general.brewing_stand_heat_increment_delay": "Velocità di accumulo di calore del supporto di infusione",
-	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1": "Specificare il numero di secondi che devono trascorrere affinché", 
-	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2": "il supporto di infusione riceva calore da una fonte di calore.",
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay": "Brewing stand heat accumulation speed",
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1": "Specify the number of seconds that need to pass", 
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2": "for the brewing speed to get heat from a heat source.",
 
-	"extraalchemy.config.general.brewing_stand_fire_max_capacity": "Limite di calore del supporto di fermentazione",
-	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1": "Specificare la capacità massima (1-20) che il supporto di infusione", 
-	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2": "può accumulare da una fonte di calore sottostante.",
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity": "Brewing stand heat limit",
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1": "Specify the maximum capacity (1-20) that the Brewing stand", 
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2": "can accumulate from a heat source underneath.",
 
 	"extraalchemy.config.general.anchor_depletes": "Consuma le àncore",
 	"extraalchemy.config.general.anchor_depletes.tooltip1": "Abilitare questa opzione fa si che le àncore consumino una carica", 

--- a/src/main/resources/assets/extraalchemy/lang/it_it.json
+++ b/src/main/resources/assets/extraalchemy/lang/it_it.json
@@ -154,6 +154,14 @@
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip1": "Abilitare questa opzione fa si che gli alambicchi vengano", 
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip2": "scaldati ogni 2 secondi se c'è una fonte di calore sotto.",
 	
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay": "Velocità di accumulo di calore del supporto di infusione",
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1": "Specificare il numero di secondi che devono trascorrere affinché", 
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2": "il supporto di infusione riceva calore da una fonte di calore.",
+
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity": "Limite di calore del supporto di fermentazione",
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1": "Specificare la capacità massima (1-20) che il supporto di infusione", 
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2": "può accumulare da una fonte di calore sottostante.",
+
 	"extraalchemy.config.general.anchor_depletes": "Consuma le àncore",
 	"extraalchemy.config.general.anchor_depletes.tooltip1": "Abilitare questa opzione fa si che le àncore consumino una carica", 
 	"extraalchemy.config.general.anchor_depletes.tooltip2": "quando i giocatori vi si teletrasportano con la poz. del ritorno.",

--- a/src/main/resources/assets/extraalchemy/lang/pt_br.json
+++ b/src/main/resources/assets/extraalchemy/lang/pt_br.json
@@ -154,6 +154,14 @@
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip1": "Habilitar isto faz com que o alambique seja reabastecido a cada", 
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip2": "2 segundos quando uma fonte de calor for colocada abaixo dele.",
 	
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay": "Velocidade de acumulação de calor do suporte de infusão",
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1": "Especifique o número de segundos que precisam passar", 
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2": "para que o suporte de infusão obtenha calor de uma fonte de calor",
+
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity": "Limite de calor do suporte de infusão",
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1": "Especifique a capacidade máxima (1-20) que o suporte de infusão", 
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2": "pode acumular de uma fonte de calor embaixo.",
+
 	"extraalchemy.config.general.anchor_depletes": "Esvaziar âncora ao retonar",
 	"extraalchemy.config.general.anchor_depletes.tooltip1": "Habilitar isto faz com que a âncora de renascimento perca as cargas quando", 
 	"extraalchemy.config.general.anchor_depletes.tooltip2": "um(a) jogador(a) se teletransporta para ela com o efeito de retrocesso",

--- a/src/main/resources/assets/extraalchemy/lang/pt_br.json
+++ b/src/main/resources/assets/extraalchemy/lang/pt_br.json
@@ -154,13 +154,13 @@
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip1": "Habilitar isto faz com que o alambique seja reabastecido a cada", 
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip2": "2 segundos quando uma fonte de calor for colocada abaixo dele.",
 	
-	"extraalchemy.config.general.brewing_stand_heat_increment_delay": "Velocidade de acumulação de calor do suporte de infusão",
-	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1": "Especifique o número de segundos que precisam passar", 
-	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2": "para que o suporte de infusão obtenha calor de uma fonte de calor",
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay": "Brewing stand heat accumulation speed",
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1": "Specify the number of seconds that need to pass", 
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2": "for the brewing speed to get heat from a heat source.",
 
-	"extraalchemy.config.general.brewing_stand_fire_max_capacity": "Limite de calor do suporte de infusão",
-	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1": "Especifique a capacidade máxima (1-20) que o suporte de infusão", 
-	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2": "pode acumular de uma fonte de calor embaixo.",
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity": "Brewing stand heat limit",
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1": "Specify the maximum capacity (1-20) that the Brewing stand", 
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2": "can accumulate from a heat source underneath.",
 
 	"extraalchemy.config.general.anchor_depletes": "Esvaziar âncora ao retonar",
 	"extraalchemy.config.general.anchor_depletes.tooltip1": "Habilitar isto faz com que a âncora de renascimento perca as cargas quando", 

--- a/src/main/resources/assets/extraalchemy/lang/ru_ru.json
+++ b/src/main/resources/assets/extraalchemy/lang/ru_ru.json
@@ -136,6 +136,14 @@
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip1": "Если включено, стойка зельеварения будет заправляться каждые", 
 	"extraalchemy.config.general.enable_brewing_stand_fire.tooltip2": "2 секунды когда под ней размещен источник тепла.",
 
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay": "Скорость заправки стойки зельеварения огнём",
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip1": "Укажите количество секунд, спустя которое стойка", 
+	"extraalchemy.config.general.brewing_stand_heat_increment_delay.tooltip2": "получит тепло от источника тепла.",
+
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity": "Ёмкость тепла в стойке от источника тепла",
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip1": "Укажите максимальную ёмкость (1-20), которую стойка зельеварения", 
+	"extraalchemy.config.general.brewing_stand_fire_max_capacity.tooltip2": "может накопить от источника тепла под ней.",
+
 	"extraalchemy.config.general.anchor_depletes": "Истощение Якоря по возвращении",
 	"extraalchemy.config.general.anchor_depletes.tooltip1": "Включение этого параметра заставляет Якорь Возрождения терять заряд,", 
 	"extraalchemy.config.general.anchor_depletes.tooltip2": "когда игроки телепортируются к нему с эффектом возврата.",


### PR DESCRIPTION
Made it so that you can set up in the settings the time delay for increasing the brewing stand fuel from heating (in seconds) and the maximum fuel limit you can get through heating.

For myself I find 300s delay and 1 fuel limit acceptable.

I've also backported this tweak and the latest changes in the repo (patchouli + proxy rework) to 1.18.2 if you'd like to release it there
https://github.com/artem-mateush/ExtraAlchemy/tree/fabric-1.18.2