### PR TITLE
Patchouli book fix

### DIFF
--- a/src/main/resources/data/extraalchemy/advancements/grant_book_on_first_join.json
+++ b/src/main/resources/data/extraalchemy/advancements/grant_book_on_first_join.json
@@ -1,0 +1,12 @@
+{
+  "criteria": {
+    "tick": {
+      "trigger": "minecraft:tick"
+    }
+  },
+  "rewards": {
+    "loot": [
+      "extraalchemy:grant_book_on_first_join"
+    ]
+  }
+}

--- a/src/main/resources/data/extraalchemy/loot_tables/grant_book_on_first_join.json
+++ b/src/main/resources/data/extraalchemy/loot_tables/grant_book_on_first_join.json
@@ -1,0 +1,20 @@
+{
+  "type": "advancement_reward",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "item",
+          "name": "patchouli:guide_book",
+          "functions": [
+            {
+              "function": "set_nbt",
+              "tag": "{\"patchouli:book\": \"extraalchemy:alchemist_guide\"}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/extraalchemy/patchouli_books/alchemist_guide/book.json
+++ b/src/main/resources/data/extraalchemy/patchouli_books/alchemist_guide/book.json
@@ -3,7 +3,7 @@
 	"landing_text": "extraalchemy.guide.description",
 	"subtitle": "extraalchemy.guide.subtitle",
 	"pamphlet": false,
-	"show_progress": false,
-	"creative_tab": "extraalchemy.all",
-	"use_resource_pack": true
+	"creative_tab": "extraalchemy:all",
+  	"use_resource_pack": true,
+  	"show_progress": false
 }


### PR DESCRIPTION
Grant alchemist guide book to new players on first join

Add advancement grant_book_on_first_join that triggers on tick and rewards the mod's Patchouli book, ensuring new players automatically receive the Alchemist Guide.

Correct creative_tab from "extraalchemy.all" to "extraalchemy:all" so the Patchouli book appears in the proper creative tab.